### PR TITLE
Fix warning on React Native 0.58.6

### DIFF
--- a/src/RecyclerViewList.js
+++ b/src/RecyclerViewList.js
@@ -288,7 +288,7 @@ class RecyclerView extends React.PureComponent {
     if (animated) {
       UIManager.dispatchViewManagerCommand(
           ReactNative.findNodeHandle(this),
-          UIManager.AndroidRecyclerViewBackedScrollView.Commands.scrollToIndex,
+          UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.scrollToIndex,
           [animated, index, velocity, viewPosition, viewOffset],
         );
     } else {
@@ -298,7 +298,7 @@ class RecyclerView extends React.PureComponent {
       }, () => {
         UIManager.dispatchViewManagerCommand(
             ReactNative.findNodeHandle(this),
-            UIManager.AndroidRecyclerViewBackedScrollView.Commands.scrollToIndex,
+            UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.scrollToIndex,
             [animated, index, velocity, viewPosition, viewOffset],
           );
       });
@@ -335,7 +335,7 @@ class RecyclerView extends React.PureComponent {
   _notifyItemMoved(currentPosition, nextPosition) {
     UIManager.dispatchViewManagerCommand(
       ReactNative.findNodeHandle(this),
-      UIManager.AndroidRecyclerViewBackedScrollView.Commands.notifyItemMoved,
+      UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.notifyItemMoved,
       [currentPosition, nextPosition],
     );
     this.forceUpdate();
@@ -344,7 +344,7 @@ class RecyclerView extends React.PureComponent {
   _notifyItemRangeInserted(position, count) {
     UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.AndroidRecyclerViewBackedScrollView.Commands.notifyItemRangeInserted,
+        UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.notifyItemRangeInserted,
         [position, count],
       );
 
@@ -371,7 +371,7 @@ class RecyclerView extends React.PureComponent {
   _notifyItemRangeRemoved(position, count) {
     UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.AndroidRecyclerViewBackedScrollView.Commands.notifyItemRangeRemoved,
+        UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.notifyItemRangeRemoved,
         [position, count],
       );
     this.forceUpdate();
@@ -380,7 +380,7 @@ class RecyclerView extends React.PureComponent {
   _notifyDataSetChanged(itemCount) {
     UIManager.dispatchViewManagerCommand(
         ReactNative.findNodeHandle(this),
-        UIManager.AndroidRecyclerViewBackedScrollView.Commands.notifyDataSetChanged,
+        UIManager.getViewManagerConfig('AndroidRecyclerViewBackedScrollView').Commands.notifyDataSetChanged,
         [itemCount],
       );
     this.setState({


### PR DESCRIPTION
I have this kind of warning after I updated to React Native 0.58.6
![image](https://user-images.githubusercontent.com/12229968/60009891-55711c80-967f-11e9-82ff-6498a87cbcc2.png)

Then I fixed it the same way as other libraries have done for example here: https://github.com/sbugert/react-native-admob/pull/413